### PR TITLE
Increase x input length for get_curve function

### DIFF
--- a/R/mean.R
+++ b/R/mean.R
@@ -1,4 +1,4 @@
-get_curve = function(pars, dev_curve, x = seq(-4, 4, length.out=1000)) {
+get_curve = function(pars, dev_curve, x = seq(-4, 6, length.out=1000)) {
   pars = as.numeric(pars)
   y = dev_curve(x, pars)
   data.frame(VG = x, ID = exp(y), stringsAsFactors = FALSE)

--- a/R/wafer_fit.R
+++ b/R/wafer_fit.R
@@ -15,14 +15,14 @@ validate_device = function(wafer) {
   ID = waferf[waferf$VG < -4, "ID"]
   if(any(ID > 1e-10)) return(FALSE)
   
-  ID = waferf[waferf$VG > 6, "ID"]
+  ID = waferf[waferf$VG > 4, "ID"]
   if(any(ID < 1e-5)) return(FALSE)
   
   waferb = wafer[wafer$direction == "Backward", ]
   ID = waferb[waferb$VG < -4, "ID"]
   if(any(ID > 1e-10)) return(FALSE)
   
-  ID = waferb[waferb$VG > 6, "ID"]
+  ID = waferb[waferb$VG > 4, "ID"]
   if(any(ID < 1e-5)) return(FALSE)
   return(TRUE)
 }

--- a/R/wafer_fit.R
+++ b/R/wafer_fit.R
@@ -63,7 +63,7 @@ add_forward_backward = function(wafer) {
 #' transformed before fitting. Devices are fitted in parallel automatically.
 #'
 #' @param wafer       Data from a single wafer
-#' @param trans       (Optional) Wafer ransform function
+#' @param trans       (Optional) Wafer transform function
 #' @param validate    (Optional) Wafer validate function
 #' @param cost_func   (Optional) Cost function
 #' @param dev_curve   (Optional) Model device voltage curve

--- a/R/wafer_fit.R
+++ b/R/wafer_fit.R
@@ -15,14 +15,14 @@ validate_device = function(wafer) {
   ID = waferf[waferf$VG < -4, "ID"]
   if(any(ID > 1e-10)) return(FALSE)
   
-  ID = waferf[waferf$VG > 4, "ID"]
+  ID = waferf[waferf$VG > 6, "ID"]
   if(any(ID < 1e-5)) return(FALSE)
   
   waferb = wafer[wafer$direction == "Backward", ]
   ID = waferb[waferb$VG < -4, "ID"]
   if(any(ID > 1e-10)) return(FALSE)
   
-  ID = waferb[waferb$VG > 4, "ID"]
+  ID = waferb[waferb$VG > 6, "ID"]
   if(any(ID < 1e-5)) return(FALSE)
   return(TRUE)
 }


### PR DESCRIPTION
Increasing x input length for `get_curve` function so that `plot_fit` and `means` will produce output over whole +ive test range i.e. from -4V to 6V (forward and backward).